### PR TITLE
[WIP] blockie-framed avatar for procedurally verifiable goodness

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ipfs-api": "^18.1.1",
     "react": "^15.4.2",
     "react-avatar-image-cropper": "^1.1.7",
-    "react-blockies": "^1.2.2",
+    "react-blockies-image": "0.0.2",
     "react-dom": "^15.4.2",
     "react-loading": "^1.0.3",
     "truffle-hdwallet-provider": "0.0.3"

--- a/src/components/EthAvatarImage.js
+++ b/src/components/EthAvatarImage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ReactLoading from 'react-loading';
-import Blockies from 'react-blockies';
+import Blockies from 'react-blockies-image';
 
 var ipfsAPI = require('ipfs-api');
 
@@ -71,7 +71,7 @@ class EthAvatarImage extends Component {
       if(this.state.imageURL) {
         return(
           <div className="eth-avatar-image">
-            <img src={this.state.imageURL} style={{ width: size, height: size, border: '1px solid black' }} role="presentation" />
+            <Blockies seed={this.props.ethAddress} image={this.state.imageURL} size={size} border={size/(size/10)} />
             {this.state.title ? (<p>Title: {this.state.title}</p>):(<p></p>)}
           </div>
         );


### PR DESCRIPTION
The major purpose of an identicon (blockie) is to visually identify an account. Simply replacing a blockie with an image breaks this functionality. It's important to preserve some procedurally verifiable data so an attacker can't just take your photo and attach it to their account. 
![image](https://user-images.githubusercontent.com/2653167/37260958-0399e25e-255e-11e8-86c2-d3de1cb609f4.png)
becomes:
![image](https://user-images.githubusercontent.com/2653167/37260965-1b1ea464-255e-11e8-9fc5-3d6cb9355ded.png)
